### PR TITLE
node-sass@4.9.0: Node Sass is no longer supported. Please use `sass` or `sass-embedded` instead.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "less": "^3.0.4",
     "less-loader": "^4.0.5",
     "mini-css-extract-plugin": "^0.4.0",
-    "node-sass": "^4.9.0",
+    "sass": "^1.0.0",
     "opn": "^5.1.0",
     "optimize-css-assets-webpack-plugin": "^4.0.1",
     "ora": "^2.1.0",


### PR DESCRIPTION
node-sass@4.9.0: Node Sass is no longer supported. Please use `sass` or `sass-embedded` instead.